### PR TITLE
Have the Dockerfile pull the code directly from the master branch on Github

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ RUN \
     curl \
     jq
 
-ADD dcosjq.sh /usr/local/bin/dcosjq
-ADD cluster-setup.sh /usr/local/bin/cluster-setup
+ADD https://raw.githubusercontent.com/some-things/dcosjq/master/dcosjq.sh /usr/local/bin/dcosjq
+ADD https://raw.githubusercontent.com/some-things/dcosjq/master/cluster-setup.sh /usr/local/bin/cluster-setup
+
+RUN chmod +x /usr/local/bin/dcosjq /usr/local/bin/cluster-setup
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
This will allow users to simply build the Docker image with the Dockerfile.  No need to have the other files locally.