### PR TITLE
Add the state of the framework to framework listing. This helps in id…

### DIFF
--- a/dcosjq.sh
+++ b/dcosjq.sh
@@ -336,7 +336,7 @@ esac
 #####
 printFrameworkList () {
   TARGET_FILE="mesos_state"
-  (echo -e "ID NAME"
+  (echo -e "ID NAME ACTIVE"
   getEndpoint | jq -r '.frameworks[] | "\(.id + " " + .name + " " + (.active | tostring))"' | sort -k 2) | column -t
 }
 

--- a/dcosjq.sh
+++ b/dcosjq.sh
@@ -337,7 +337,7 @@ esac
 printFrameworkList () {
   TARGET_FILE="mesos_state"
   (echo -e "ID NAME"
-  getEndpoint | jq -r '.frameworks[] | "\(.id + " " + .name)"' | sort -k 2) | column -t
+  getEndpoint | jq -r '.frameworks[] | "\(.id + " " + .name + " " + (.active | tostring))"' | sort -k 2) | column -t
 }
 
 # Need to do something better with this... Perhaps just print similar output to the summary (using only mesos state) but more readable...


### PR DESCRIPTION
…entifying the inactive frameworks when the multiple framework with the same name exists in the state.